### PR TITLE
Rename built image

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -61,4 +61,5 @@ go mod vendor
 cd scripts
 ./default
 mkdir -p ../../dist/artifacts
-cp ../dist/artifacts/* ../../dist/artifacts
+mv ../dist/artifacts/* ../../dist/artifacts
+for file in `find ../../dist/artifacts -type f -name '*.iso'`; do mv "$file" "${file/k3os/harvester}"; done


### PR DESCRIPTION
rename the built iso image from k3os-amd64.iso to harvester-amd64.iso