### PR TITLE
Revert "K3OS: change sh symlink"

### DIFF
--- a/k3os/images/05-base/Dockerfile
+++ b/k3os/images/05-base/Dockerfile
@@ -4,6 +4,3 @@ FROM ${REPO}/k3os-base:${TAG} AS base
 RUN apk --no-cache add \
     grub-bios \
     open-vm-tools
-# symlink sh to busybox instead of the default /bin/busybox
-# The default breaks when the rootfs is mounted to a directory inside a container
-RUN rm /bin/sh && ln -s busybox /bin/sh


### PR DESCRIPTION
This reverts commit 114373c8604504d216bca4035f8714ad38ae8e1d.

The issue is fixed on the Longhorn side so this workaround is not needed with longhorn-v1.1.0-rc2+