### PR TITLE
Remove longhorn namespace in manifests

### DIFF
--- a/pkg/console/util.go
+++ b/pkg/console/util.go
@@ -223,11 +223,6 @@ kind: Namespace
 metadata:
   name: harvester-system
 ---
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: longhorn-system
----
 apiVersion: helm.cattle.io/v1
 kind: HelmChart
 metadata:


### PR DESCRIPTION
The namespace creation is handled in the chart