### PR TITLE
Support automatic installation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/tredoe/osutil v1.0.5
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/apimachinery v0.0.0
 )
 

--- a/k3os/images/output/01-full/Dockerfile
+++ b/k3os/images/output/01-full/Dockerfile
@@ -15,4 +15,6 @@ ARG TAG
 FROM ${REPO}/k3os-base:${TAG}
 ARG ARCH
 
+COPY --from=kernel /output/vmlinuz /output/k3os-vmlinuz-${ARCH}
+COPY --from=kernel /output/initrd /output/k3os-initrd-${ARCH}
 COPY --from=iso /output/k3os.iso /output/k3os-${ARCH}.iso

--- a/k3os/install.sh
+++ b/k3os/install.sh
@@ -13,6 +13,7 @@ get_url()
 {
     FROM=$1
     TO=$2
+    echo "Downloading ${FROM} to ${TO}..."
     case $FROM in
         ftp*|http*|tftp*)
             n=0

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,23 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHarvesterConfig_sanitized(t *testing.T) {
+	c := NewHarvesterConfig()
+	c.Password = `#3tQ66t!`
+	c.Token = `3mO3&nEJ`
+	c.Wifi = []Wifi{{Name: "wifi1", Passphrase: `^s2I8Y2P`}}
+
+	expected := NewHarvesterConfig()
+	expected.Password = SanitizeMask
+	expected.Token = SanitizeMask
+	expected.Wifi = []Wifi{{Name: "wifi1", Passphrase: SanitizeMask}}
+
+	s, err := c.sanitized()
+	assert.Equal(t, nil, err)
+	assert.Equal(t, expected, s)
+}

--- a/pkg/config/read.go
+++ b/pkg/config/read.go
@@ -1,0 +1,72 @@
+package config
+
+import (
+	"io/ioutil"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/rancher/mapper/convert"
+	"github.com/rancher/mapper/values"
+)
+
+const (
+	kernelParamPrefix = "harvester"
+)
+
+// ReadConfig constructs a config by reading various sources
+func ReadConfig() (HarvesterConfig, error) {
+	result := NewHarvesterConfig()
+	data, err := readCmdline()
+	if err != nil {
+		return *result, err
+	}
+	schema.Mapper.ToInternal(data)
+	return *result, convert.ToObj(data, result)
+}
+
+// parse kernel parameters that have `prefix.` prefix
+func parseCmdLine(cmdline string, prefix string) (map[string]interface{}, error) {
+	//supporting regex https://regexr.com/4mq0s
+	parser, err := regexp.Compile(`(\"[^\"]+\")|([^\s]+=(\"[^\"]+\")|([^\s]+))`)
+	if err != nil {
+		return nil, nil
+	}
+
+	data := map[string]interface{}{}
+	for _, item := range parser.FindAllString(cmdline, -1) {
+		parts := strings.SplitN(item, "=", 2)
+		value := "true"
+		if len(parts) > 1 {
+			value = strings.Trim(parts[1], `"`)
+		}
+		keys := strings.Split(strings.Trim(parts[0], `"`), ".")
+		if !strings.HasPrefix(keys[0], prefix) {
+			continue
+		}
+		keys = keys[1:]
+		existing, ok := values.GetValue(data, keys...)
+		if ok {
+			switch v := existing.(type) {
+			case string:
+				values.PutValue(data, []string{v, value}, keys...)
+			case []string:
+				values.PutValue(data, append(v, value), keys...)
+			}
+		} else {
+			values.PutValue(data, value, keys...)
+		}
+	}
+
+	return data, nil
+}
+
+func readCmdline() (map[string]interface{}, error) {
+	bytes, err := ioutil.ReadFile("/proc/cmdline")
+	if os.IsNotExist(err) {
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+	return parseCmdLine(string(bytes), kernelParamPrefix)
+}

--- a/pkg/config/read_test.go
+++ b/pkg/config/read_test.go
@@ -1,0 +1,22 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseCmdLine(t *testing.T) {
+	cmdline := `x y harvester.a.b=true "harvester.c=d" harvester.e harvester.f=1 harvester.f=2`
+	m, err := parseCmdLine(cmdline, kernelParamPrefix)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]interface{}{
+		"a": map[string]interface{}{"b": "true"},
+		"c": "d",
+		"e": "true",
+		"f": []string{"1", "2"},
+	}
+	assert.Equal(t, want, m)
+}

--- a/pkg/config/schemas_test.go
+++ b/pkg/config/schemas_test.go
@@ -3,78 +3,27 @@ package config
 import (
 	"testing"
 
-	"github.com/rancher/k3os/pkg/config"
+	"github.com/rancher/harvester-installer/pkg/util"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestToCloudConfig(t *testing.T) {
+func TestToHarvesterConfig(t *testing.T) {
 	testCases := []struct {
 		input    []byte
-		expected *config.CloudConfig
+		expected *HarvesterConfig
 		err      error
 	}{
 		{
-			input: []byte(`ssh_authorized_keys:
-- ssh-rsa AAAAB3NzaC1yc2EAAAADAQAB...
-- github:username
-hostname: myhost
-init_cmd:
-- "echo hello, init command"
-boot_cmd:
-- "echo hello, boot command"
-run_cmd:
-- "echo hello, run command"
-k3os:
-  data_sources:
-  - aws
-  - cdrom
-  modules:
-  - kvm
-  - nvme
-  sysctl:
-    kernel.printk: "4 4 1 7"
-    kernel.kptr_restrict: "1"
-  dns_nameservers:
-  - 8.8.8.8
-  - 1.1.1.1
-  ntp_servers:
-  - 0.us.pool.ntp.org
-  - 1.us.pool.ntp.org
-  wifi:
-  - name: home
-    passphrase: mypassword
-  - name: nothome
-    passphrase: somethingelse
-  password: rancher
-  server_url: https://someserver:6443
-  token: TOKEN_VALUE
-  labels:
-    region: us-west-1
-    somekey: somevalue
-  k3s_args:
-  - server
-  - "--disable-agent"
-  environment:
-    http_proxy: http://myserver
-    https_proxy: http://myserver
-  taints:
-  - key1=value1:NoSchedule
-  - key1=value1:NoExecute
-`),
-			expected: &config.CloudConfig{
-				SSHAuthorizedKeys: []string{
-					"ssh-rsa AAAAB3NzaC1yc2EAAAADAQAB...",
-					"github:username",
-				},
-				Hostname: "myhost",
-				Initcmd:  []string{"echo hello, init command"},
-				Runcmd:   []string{"echo hello, run command"},
-				Bootcmd:  []string{"echo hello, boot command"},
-				K3OS: config.K3OS{
-					DataSources: []string{
-						"aws",
-						"cdrom",
+			input: util.LoadFixture(t, "harvester-config.yaml"),
+			expected: &HarvesterConfig{
+				ServerURL: "https://someserver:6443",
+				Token:     "TOKEN_VALUE",
+				OS: OS{
+					SSHAuthorizedKeys: []string{
+						"ssh-rsa AAAAB3NzaC1yc2EAAAADAQAB...",
+						"github:username",
 					},
+					Hostname: "myhost",
 					Modules: []string{
 						"kvm",
 						"nvme",
@@ -91,7 +40,7 @@ k3os:
 						"0.us.pool.ntp.org",
 						"1.us.pool.ntp.org",
 					},
-					Wifi: []config.Wifi{
+					Wifi: []Wifi{
 						{
 							Name:       "home",
 							Passphrase: "mypassword",
@@ -101,25 +50,23 @@ k3os:
 							Passphrase: "somethingelse",
 						},
 					},
-					Password:  "rancher",
-					ServerURL: "https://someserver:6443",
-					Token:     "TOKEN_VALUE",
-					Labels: map[string]string{
-						"region":  "us-west-1",
-						"somekey": "somevalue",
-					},
-					K3sArgs: []string{
-						"server",
-						"--disable-agent",
-					},
+					Password: "rancher",
 					Environment: map[string]string{
 						"http_proxy":  "http://myserver",
 						"https_proxy": "http://myserver",
 					},
-					Taints: []string{
-						"key1=value1:NoSchedule",
-						"key1=value1:NoExecute",
-					},
+				},
+				Install: Install{
+					Mode:          "create",
+					MgmtInterface: "eth0",
+					ForceEFI:      true,
+					Device:        "/dev/vda",
+					Silent:        true,
+					ISOURL:        "http://myserver/test.iso",
+					PowerOff:      true,
+					NoFormat:      true,
+					Debug:         true,
+					TTY:           "ttyS0",
 				},
 			},
 			err: nil,
@@ -127,7 +74,7 @@ k3os:
 	}
 
 	for _, testCase := range testCases {
-		output, err := ToCloudConfig(testCase.input)
+		output, err := LoadHarvesterConfig(testCase.input)
 		assert.Equal(t, testCase.expected, output)
 		assert.Equal(t, testCase.err, err)
 	}

--- a/pkg/config/testdata/harvester-config.yaml
+++ b/pkg/config/testdata/harvester-config.yaml
@@ -1,0 +1,40 @@
+server_url: https://someserver:6443
+token: TOKEN_VALUE
+os:
+  ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQAB...
+  - github:username
+  hostname: myhost
+  modules:
+  - kvm
+  - nvme
+  sysctl:
+    kernel.printk: "4 4 1 7"
+    kernel.kptr_restrict: "1"
+  dns_nameservers:
+  - 8.8.8.8
+  - 1.1.1.1
+  ntp_servers:
+  - 0.us.pool.ntp.org
+  - 1.us.pool.ntp.org
+  wifi:
+  - name: home
+    passphrase: mypassword
+  - name: nothome
+    passphrase: somethingelse
+  password: rancher
+  environment:
+    http_proxy: http://myserver
+    https_proxy: http://myserver
+install:
+  mode: create
+  mgmtInterface: eth0
+  force_efi: true
+  device: /dev/vda
+  silent: true
+  iso_url: http://myserver/test.iso
+  poweroff: true
+  no_format: true
+  debug: true
+  tty: ttyS0
+

--- a/pkg/config/write.go
+++ b/pkg/config/write.go
@@ -1,0 +1,29 @@
+package config
+
+import (
+	"github.com/rancher/mapper/convert"
+	"gopkg.in/yaml.v2"
+)
+
+func PrintInstall(cfg HarvesterConfig) ([]byte, error) {
+	data, err := convert.EncodeToMap(cfg.Install)
+	if err != nil {
+		return nil, err
+	}
+
+	toYAMLKeys(data)
+	return yaml.Marshal(data)
+}
+
+func toYAMLKeys(data map[string]interface{}) {
+	for k, v := range data {
+		if sub, ok := v.(map[string]interface{}); ok {
+			toYAMLKeys(sub)
+		}
+		newK := convert.ToYAMLKey(k)
+		if newK != k {
+			delete(data, k)
+			data[newK] = v
+		}
+	}
+}

--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/jroimartin/gocui"
+	"github.com/rancher/harvester-installer/pkg/config"
 	"github.com/rancher/harvester-installer/pkg/widgets"
 	"github.com/sirupsen/logrus"
 )
@@ -32,6 +33,7 @@ type Console struct {
 	context context.Context
 	*gocui.Gui
 	elements map[string]widgets.Element
+	config   *config.HarvesterConfig
 }
 
 // RunConsole starts the console
@@ -56,6 +58,7 @@ func NewConsole() (*Console, error) {
 		context:  context.Background(),
 		Gui:      g,
 		elements: make(map[string]widgets.Element),
+		config:   config.NewHarvesterConfig(),
 	}, nil
 }
 

--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -702,7 +702,7 @@ func addInstallPanel(c *Console) error {
 			if c.config.Hostname == "" {
 				c.config.Hostname = "harvester-" + rand.String(5)
 			}
-			if err := validateConfig(Validator{}, c.config); err != nil {
+			if err := validateConfig(ConfigValidator{}, c.config); err != nil {
 				printToInstallPanel(c.Gui, err.Error())
 				return
 			}

--- a/pkg/console/testdata/create-cc.yaml
+++ b/pkg/console/testdata/create-cc.yaml
@@ -1,0 +1,76 @@
+ssh_authorized_keys:
+- ssh-rsa AAAAB3NzaC1yc2EAAAADAQAB...
+- github:username
+hostname: myhost
+writeFiles:
+- content: |
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: harvester-system
+    ---
+    apiVersion: helm.cattle.io/v1
+    kind: HelmChart
+    metadata:
+      name: harvester
+      namespace: kube-system
+    spec:
+      chart: https://%{KUBERNETES_API}%/static/charts/harvester-0.1.0.tgz
+      targetNamespace: harvester-system
+      set:
+        minio.persistence.storageClass: "longhorn"
+        containers.apiserver.image.imagePullPolicy: "IfNotPresent"
+        harvester-network-controller.image.pullPolicy: "IfNotPresent"
+        service.harvester.type: "LoadBalancer"
+        containers.apiserver.authMode: "localUser"
+        multus.enabled: "true"
+        longhorn.enabled: "true"
+  encoding: ""
+  owner: root
+  path: /var/lib/rancher/k3s/server/manifests/harvester.yaml
+  permissions: "0600"
+k3os:
+  modules:
+  - kvm
+  - nvme
+  sysctl:
+    kernel.printk: "4 4 1 7"
+    kernel.kptr_restrict: "1"
+  dns_nameservers:
+  - 8.8.8.8
+  - 1.1.1.1
+  ntp_servers:
+  - 0.us.pool.ntp.org
+  - 1.us.pool.ntp.org
+  wifi:
+  - name: home
+    passphrase: mypassword
+  - name: nothome
+    passphrase: somethingelse
+  password: rancher
+  token: TOKEN_VALUE
+  environment:
+    http_proxy: http://myserver
+    https_proxy: http://myserver
+  k3sArgs:
+  - server
+  - --cluster-init
+  - --disable
+  - local-storage
+  - --flannel-iface
+  - eth0
+  labels:
+    harvester.cattle.io/managed: "true"
+    svccontroller.k3s.cattle.io/enablelb: "true"
+  install:
+    mode: create
+    mgmtInterface: eth0
+    force_efi: true
+    device: /dev/vda
+    silent: true
+    iso_url: http://myserver/test.iso
+    poweroff: true
+    no_format: true
+    debug: true
+    tty: ttyS0
+

--- a/pkg/console/testdata/create.yaml
+++ b/pkg/console/testdata/create.yaml
@@ -1,0 +1,39 @@
+token: TOKEN_VALUE
+os:
+  ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQAB...
+  - github:username
+  hostname: myhost
+  modules:
+  - kvm
+  - nvme
+  sysctl:
+    kernel.printk: "4 4 1 7"
+    kernel.kptr_restrict: "1"
+  dns_nameservers:
+  - 8.8.8.8
+  - 1.1.1.1
+  ntp_servers:
+  - 0.us.pool.ntp.org
+  - 1.us.pool.ntp.org
+  wifi:
+  - name: home
+    passphrase: mypassword
+  - name: nothome
+    passphrase: somethingelse
+  password: rancher
+  environment:
+    http_proxy: http://myserver
+    https_proxy: http://myserver
+install:
+  mode: create
+  mgmtInterface: eth0
+  force_efi: true
+  device: /dev/vda
+  silent: true
+  iso_url: http://myserver/test.iso
+  poweroff: true
+  no_format: true
+  debug: true
+  tty: ttyS0
+

--- a/pkg/console/testdata/join-cc.yaml
+++ b/pkg/console/testdata/join-cc.yaml
@@ -1,0 +1,46 @@
+ssh_authorized_keys:
+- ssh-rsa AAAAB3NzaC1yc2EAAAADAQAB...
+- github:username
+hostname: myhost
+k3os:
+  modules:
+  - kvm
+  - nvme
+  sysctl:
+    kernel.printk: "4 4 1 7"
+    kernel.kptr_restrict: "1"
+  dns_nameservers:
+  - 8.8.8.8
+  - 1.1.1.1
+  ntp_servers:
+  - 0.us.pool.ntp.org
+  - 1.us.pool.ntp.org
+  wifi:
+  - name: home
+    passphrase: mypassword
+  - name: nothome
+    passphrase: somethingelse
+  password: rancher
+  server_url: https://somewhere:6443
+  token: TOKEN_VALUE
+  environment:
+    http_proxy: http://myserver
+    https_proxy: http://myserver
+  k3sArgs:
+  - agent
+  - --flannel-iface
+  - eth0
+  labels:
+    harvester.cattle.io/managed: "true"
+  install:
+    mode: create
+    mgmtInterface: eth0
+    force_efi: true
+    device: /dev/vda
+    silent: true
+    iso_url: http://myserver/test.iso
+    poweroff: true
+    no_format: true
+    debug: true
+    tty: ttyS0
+

--- a/pkg/console/testdata/join.yaml
+++ b/pkg/console/testdata/join.yaml
@@ -1,0 +1,40 @@
+server_url: https://somewhere:6443
+token: TOKEN_VALUE
+os:
+  ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQAB...
+  - github:username
+  hostname: myhost
+  modules:
+  - kvm
+  - nvme
+  sysctl:
+    kernel.printk: "4 4 1 7"
+    kernel.kptr_restrict: "1"
+  dns_nameservers:
+  - 8.8.8.8
+  - 1.1.1.1
+  ntp_servers:
+  - 0.us.pool.ntp.org
+  - 1.us.pool.ntp.org
+  wifi:
+  - name: home
+    passphrase: mypassword
+  - name: nothome
+    passphrase: somethingelse
+  password: rancher
+  environment:
+    http_proxy: http://myserver
+    https_proxy: http://myserver
+install:
+  mode: join
+  mgmtInterface: eth0
+  force_efi: true
+  device: /dev/vda
+  silent: true
+  iso_url: http://myserver/test.iso
+  poweroff: true
+  no_format: true
+  debug: true
+  tty: ttyS0
+

--- a/pkg/console/validator.go
+++ b/pkg/console/validator.go
@@ -1,0 +1,106 @@
+package console
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/pkg/errors"
+	"github.com/rancher/harvester-installer/pkg/config"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	ErrMsgModeCreateContainsServerURL   = fmt.Sprintf("ServerURL need to be empty in %s mode", modeCreate)
+	ErrMsgModeJoinServerURLNotSpecified = fmt.Sprintf("ServerURL can't empty in %s mode", modeJoin)
+	ErrMsgModeUnknown                   = "Unknown mode"
+	ErrMsgTokenNotSpecified             = "token not specified"
+
+	ErrMsgMgmtInterfaceNotSpecified = "no management interface specified"
+	ErrMsgMgmtInterfaceNotFoud      = "interface not found"
+	ErrMsgMgmtInterfaceIsLoop       = "interface is a loopbck interface"
+	ErrMsgDeviceNotSpecified        = "no device specified"
+	ErrMsgDeviceNotFound            = "device not found"
+	ErrMsgNoCredentials             = "no SSH authorized keys or passwords are set"
+)
+
+type ValidatorInterface interface {
+	checkMgmtInterface(name string) error
+	checkDevice(device string) error
+}
+
+type Validator struct {
+}
+
+func prettyError(errMsg string, value string) error {
+	return errors.Errorf("%s: %s", errMsg, value)
+}
+
+func (v Validator) checkMgmtInterface(name string) error {
+	if name == "" {
+		return errors.New(ErrMsgMgmtInterfaceNotSpecified)
+	}
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return err
+	}
+	for _, i := range ifaces {
+		if i.Name == name {
+			if i.Flags&net.FlagLoopback != 0 {
+				return prettyError(ErrMsgMgmtInterfaceIsLoop, name)
+			}
+			return nil
+		}
+	}
+	return prettyError(ErrMsgMgmtInterfaceNotFoud, name)
+}
+
+func (Validator) checkDevice(device string) error {
+	if device == "" {
+		return errors.New(ErrMsgDeviceNotSpecified)
+	}
+	options, err := getDiskOptions()
+	if err != nil {
+		return err
+	}
+	for _, option := range options {
+		if device == option.Value {
+			return nil
+		}
+	}
+	return prettyError(ErrMsgDeviceNotFound, device)
+}
+
+func validateConfig(v ValidatorInterface, cfg *config.HarvesterConfig) error {
+	logrus.Debug("Validating config: ", cfg)
+
+	// modes
+	switch mode := cfg.Install.Mode; mode {
+	case modeCreate:
+		if cfg.ServerURL != "" {
+			return errors.New(ErrMsgModeCreateContainsServerURL)
+		}
+	case modeJoin:
+		if cfg.ServerURL == "" {
+			return errors.New(ErrMsgModeJoinServerURLNotSpecified)
+		}
+	default:
+		return prettyError(ErrMsgModeUnknown, mode)
+	}
+
+	if cfg.Token == "" {
+		return errors.New(ErrMsgTokenNotSpecified)
+	}
+
+	if len(cfg.SSHAuthorizedKeys) == 0 && cfg.Password == "" {
+		return errors.New(ErrMsgNoCredentials)
+	}
+
+	if err := v.checkMgmtInterface(cfg.Install.MgmtInterface); err != nil {
+		return err
+	}
+
+	if err := v.checkDevice(cfg.Install.Device); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/console/validator_test.go
+++ b/pkg/console/validator_test.go
@@ -9,12 +9,22 @@ import (
 )
 
 type FakeValidator struct {
-	interfaces []string
-	devices    []string
+	hasInterfaces []string
+	hasDevices    []string
+}
+
+func (v FakeValidator) Validate(cfg *config.HarvesterConfig) error {
+	if err := v.checkMgmtInterface(cfg.Install.MgmtInterface); err != nil {
+		return err
+	}
+	if err := v.checkDevice(cfg.Install.Device); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (v FakeValidator) checkMgmtInterface(name string) error {
-	for _, i := range v.interfaces {
+	for _, i := range v.hasInterfaces {
 		if i == name {
 			return nil
 		}
@@ -23,7 +33,7 @@ func (v FakeValidator) checkMgmtInterface(name string) error {
 }
 
 func (v FakeValidator) checkDevice(device string) error {
-	for _, d := range v.devices {
+	for _, d := range v.hasDevices {
 		if d == device {
 			return nil
 		}
@@ -33,8 +43,8 @@ func (v FakeValidator) checkDevice(device string) error {
 
 func createDefaultFakeValidator() FakeValidator {
 	return FakeValidator{
-		interfaces: []string{"eth0"},
-		devices:    []string{"/dev/vda"},
+		hasInterfaces: []string{"eth0"},
+		hasDevices:    []string{"/dev/vda"},
 	}
 }
 

--- a/pkg/console/validator_test.go
+++ b/pkg/console/validator_test.go
@@ -1,0 +1,151 @@
+package console
+
+import (
+	"testing"
+
+	"github.com/rancher/harvester-installer/pkg/config"
+	"github.com/rancher/harvester-installer/pkg/util"
+	"github.com/stretchr/testify/assert"
+)
+
+type FakeValidator struct {
+	interfaces []string
+	devices    []string
+}
+
+func (v FakeValidator) checkMgmtInterface(name string) error {
+	for _, i := range v.interfaces {
+		if i == name {
+			return nil
+		}
+	}
+	return prettyError(ErrMsgMgmtInterfaceNotFoud, name)
+}
+
+func (v FakeValidator) checkDevice(device string) error {
+	for _, d := range v.devices {
+		if d == device {
+			return nil
+		}
+	}
+	return prettyError(ErrMsgDeviceNotFound, device)
+}
+
+func createDefaultFakeValidator() FakeValidator {
+	return FakeValidator{
+		interfaces: []string{"eth0"},
+		devices:    []string{"/dev/vda"},
+	}
+}
+
+func loadConfig(t *testing.T, name string) *config.HarvesterConfig {
+	c, err := config.LoadHarvesterConfig(util.LoadFixture(t, name))
+	if err != nil {
+		t.Fatal("fail to load config: ", err)
+	}
+	return c
+}
+
+func TestValidateConfig(t *testing.T) {
+	createCreateConfig := func() *config.HarvesterConfig {
+		return &config.HarvesterConfig{
+			Token: "token",
+			OS: config.OS{
+				SSHAuthorizedKeys: []string{"github: someuser"},
+				Password:          "password",
+			},
+			Install: config.Install{
+				Mode:          modeCreate,
+				MgmtInterface: "eth0",
+				Device:        "/dev/vda",
+			},
+		}
+	}
+
+	createJoinConfig := func() *config.HarvesterConfig {
+		c := createCreateConfig()
+		c.ServerURL = "https://somewhere"
+		c.Mode = modeJoin
+		return c
+	}
+
+	testCases := []struct {
+		name     string
+		cfg      *config.HarvesterConfig
+		preApply func(c *config.HarvesterConfig)
+		errMsg   string
+	}{
+		{
+			name: "valid create config",
+			cfg:  createCreateConfig(),
+		},
+		{
+			name: "invalid create config: contains server URL",
+			cfg:  createCreateConfig(),
+			preApply: func(c *config.HarvesterConfig) {
+				c.ServerURL = "https://somewhere"
+			},
+			errMsg: ErrMsgModeCreateContainsServerURL,
+		},
+		{
+			name: "invalid config: unknown mode",
+			cfg:  createCreateConfig(),
+			preApply: func(c *config.HarvesterConfig) {
+				c.Mode = "asdf"
+			},
+			errMsg: ErrMsgModeUnknown,
+		},
+		{
+			name: "valid join config",
+			cfg:  createJoinConfig(),
+		},
+		{
+			name: "invalid join config: no server URL",
+			cfg:  createJoinConfig(),
+			preApply: func(c *config.HarvesterConfig) {
+				c.ServerURL = ""
+			},
+			errMsg: ErrMsgModeJoinServerURLNotSpecified,
+		},
+		{
+			name: "invalid create config: contains no credential",
+			cfg:  createCreateConfig(),
+			preApply: func(c *config.HarvesterConfig) {
+				c.SSHAuthorizedKeys = nil
+				c.Password = ""
+			},
+			errMsg: ErrMsgNoCredentials,
+		},
+		{
+			name: "invalid create config: device not found",
+			cfg:  createCreateConfig(),
+			preApply: func(c *config.HarvesterConfig) {
+				c.Device = "/dev/vdb"
+			},
+			errMsg: ErrMsgDeviceNotFound,
+		},
+		{
+			name: "invalid create config: interface not found",
+			cfg:  createCreateConfig(),
+			preApply: func(c *config.HarvesterConfig) {
+				c.MgmtInterface = "eth1"
+			},
+			errMsg: ErrMsgMgmtInterfaceNotFoud,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if testCase.preApply != nil {
+				testCase.preApply(testCase.cfg)
+			}
+			err := validateConfig(createDefaultFakeValidator(), testCase.cfg)
+			if testCase.errMsg == "" {
+				assert.Nil(t, err)
+			} else {
+				assert.NotNil(t, err)
+				assert.Contains(t, err.Error(), testCase.errMsg)
+			}
+		})
+	}
+}

--- a/pkg/util/cloud_config.go
+++ b/pkg/util/cloud_config.go
@@ -1,4 +1,4 @@
-package config
+package util
 
 import (
 	"fmt"
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	schemas = mapper.NewSchemas().Init(func(s *mapper.Schemas) *mapper.Schemas {
+	ccSchemas = mapper.NewSchemas().Init(func(s *mapper.Schemas) *mapper.Schemas {
 		s.DefaultMappers = func() []mapper.Mapper {
 			return []mapper.Mapper{
 				config.NewToMap(),
@@ -20,16 +20,20 @@ var (
 			}
 		}
 		return s
-	}).MustImport(HarvesterConfig{})
-	schema = schemas.Schema("harvesterConfig")
+	}).MustImport(config.CloudConfig{})
+	ccSchema = ccSchemas.Schema("cloudConfig")
 )
 
-func LoadHarvesterConfig(yamlBytes []byte) (*HarvesterConfig, error) {
-	result := NewHarvesterConfig()
+func LoadCloudConfig(yamlBytes []byte) (*config.CloudConfig, error) {
+	result := &config.CloudConfig{
+		K3OS: config.K3OS{
+			Install: &config.Install{},
+		},
+	}
 	data := map[string]interface{}{}
 	if err := yaml.Unmarshal(yamlBytes, &data); err != nil {
 		return result, fmt.Errorf("failed to unmarshal yaml: %v", err)
 	}
-	schema.Mapper.ToInternal(data)
+	ccSchema.Mapper.ToInternal(data)
 	return result, convert.ToObj(data, result)
 }

--- a/pkg/util/test.go
+++ b/pkg/util/test.go
@@ -1,0 +1,17 @@
+package util
+
+import (
+	"io/ioutil"
+	"path"
+	"testing"
+)
+
+// LoadFixture loads a testing fixture from testdata dir
+func LoadFixture(t *testing.T, name string) []byte {
+	path := path.Join("testdata", name)
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		t.Fatalf("Fail to load fixture %q", path)
+	}
+	return data
+}

--- a/scripts/build
+++ b/scripts/build
@@ -82,3 +82,5 @@ cd scripts
 mkdir -p ../../dist/artifacts
 mv ../dist/artifacts/* ../../dist/artifacts
 for file in `find ../../dist/artifacts -type f -name '*.iso'`; do mv "$file" "${file/k3os/harvester}"; done
+for file in `find ../../dist/artifacts -type f -name 'k3os-vmlinuz-*'`; do mv "$file" "${file/k3os/harvester}"; done
+for file in `find ../../dist/artifacts -type f -name 'k3os-initrd-*'`; do mv "$file" "${file/k3os/harvester}"; done


### PR DESCRIPTION
Partially fixed: https://github.com/rancher/harvester/issues/217

## How it works

Support automatic installation

- Add Harvester config
  - The installer now accepts Harvester config and converts the config to any internal form if needed. (e.g., k3os CloudConfig).
- Add kernel parameters to support automatic installation
  - `harvester.install.automatic=true`. If this parameter is specified, then the installer is in automatic mode. No questions will be asked.
  - `harvester.install.config_url=http://to.my/config`. The installer will fetch the config at this URL and perform the automatic installation.

## Example

### Create mode

*iPXE script*
```
kernel harvester/vmlinuz k3os.mode=install console=ttyS0 console=tty1 harvester.install.automatic=true harvester.install.config_url=http://10.100.0.10/config-create.yaml
initrd harvester/initrd
boot
```

Where:
 - `k3os.install.config_url=http://10.100.0.10/config-create.yaml`: The Harvester config to be used.
   - e.g.,
```yaml
token: token
os:
  hostname: node1
  ssh_authorized_keys:
  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDbeUa9A7Kee+hcCleIXYxuaPksn2m4PZTd4T7wPcse8KbsQfttGRax6vxQXoPO6ehddqOb2nV7tkW2mEhR50OE7W7ngDHbzK2OneAyONYF44bmMsapNAGvnsBKe9rNrev1iVBwOjtmyVLhnLrJIX+2+3T3yauxdu+pmBsnD5OIKUrBrN1sdwW0rA2rHDiSnzXHNQM3m02aY6mlagdQ/Ovh96h05QFCHYxBc6oE/mIeFRaNifa4GU/oELn3a6HfbETeBQz+XOEN+IrLpnZO9riGyzsZroB/Y3Ju+cJxH06U0B7xwJCRmWZjuvfFQUP7RIJD1gRGZzmf3h8+F+oidkO2i5rbT57NaYSqkdVvR6RidVLWEzURZIGbtHjSPCi4kqD05ua8r/7CC0PvxQb1O5ILEdyJr2ZmzhF6VjjgmyrmSmt/yRq8MQtGQxyKXZhJqlPYho4d5SrHi5iGT2PvgDQaWch0I3ndEicaaPDZJHWBxVsCVAe44Wtj9g3LzXkyu3k= root@admin
  password: rancher
install:
  mode: create
  mgmt_interface: eth0
  device: /dev/sda
  iso_url: http://10.100.0.10/harvester-amd64.iso
```
Note the `install.mode` is `create`. 

### Join mode

*iPXE script*
```
kernel harvester/vmlinuz k3os.mode=install console=ttyS0 console=tty1 harvester.install.automatic=true harvester.install.config_url=http://10.100.0.10/config-join.yaml
initrd harvester/initrd
boot
```

 - `k3os.install.config_url=http://10.100.0.10/config-join.yaml`: The Harvester config to be used.
   - e.g.,
```yaml
server_url: https://10.100.0.130:6443
token: token
os:
  hostname: node1
  ssh_authorized_keys:
  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDbeUa9A7Kee+hcCleIXYxuaPksn2m4PZTd4T7wPcse8KbsQfttGRax6vxQXoPO6ehddqOb2nV7tkW2mEhR50OE7W7ngDHbzK2OneAyONYF44bmMsapNAGvnsBKe9rNrev1iVBwOjtmyVLhnLrJIX+2+3T3yauxdu+pmBsnD5OIKUrBrN1sdwW0rA2rHDiSnzXHNQM3m02aY6mlagdQ/Ovh96h05QFCHYxBc6oE/mIeFRaNifa4GU/oELn3a6HfbETeBQz+XOEN+IrLpnZO9riGyzsZroB/Y3Ju+cJxH06U0B7xwJCRmWZjuvfFQUP7RIJD1gRGZzmf3h8+F+oidkO2i5rbT57NaYSqkdVvR6RidVLWEzURZIGbtHjSPCi4kqD05ua8r/7CC0PvxQb1O5ILEdyJr2ZmzhF6VjjgmyrmSmt/yRq8MQtGQxyKXZhJqlPYho4d5SrHi5iGT2PvgDQaWch0I3ndEicaaPDZJHWBxVsCVAe44Wtj9g3LzXkyu3k= root@admin
  password: rancher
install:
  mode: join 
  mgmt_interface: eth0
  device: /dev/sda
  iso_url: http://10.100.0.10/harvester-amd64.iso
```
Note the `install.mode` is `join` and `server_url` needs to be provided.



## Discussion

**Update: we discussed this in sync call and decided to go this way**

Another idea is to completely not using k3os parameters and configs. Instead, we can use harvester-only parameters and configs, then convert them to k3os configs internally. For example, we can have a `harvester.install.iso_url` parameter rather than using `k3os.install.iso_url`.

 The advantages of this approach are:
  - It's clear: the user doesn't need to know k3os at all.
  - If the underlying OS is switched to another distro in the future, the user doesn't need to change the boot parameters.
 
