### PR TITLE
Support http proxy and exclude offline images

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,5 +1,15 @@
 FROM golang:1.13.4-alpine3.10
 
+ARG http_proxy=$http_proxy
+ARG https_proxy=$https_proxy
+ARG no_proxy=$no_proxy
+ENV http_proxy=$http_proxy
+ENV https_proxy=$https_proxy
+ENV no_proxy=$no_proxy
+
+ARG HARVESTER_INSTALLER_OFFLINE_BUILD
+ENV HARVESTER_INSTALLER_OFFLINE_BUILD=$HARVESTER_INSTALLER_OFFLINE_BUILD
+
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
 

--- a/k3os/install.sh
+++ b/k3os/install.sh
@@ -158,50 +158,50 @@ do_copy()
 
     offline_image_path="var/lib/rancher/k3s/agent/images/harvester-images.tar"
     if [ -f "${root_path}/${offline_image_path}.zst" ]; then
-        echo "Decompressing container images"
-        zstd -d --rm "${root_path}/${offline_image_path}.zst" -o "${root_path}/${offline_image_path}" > /dev/null
-    fi
-    echo "Loading images. This may take a few minutes"
-    cd ${root_path}
-    mkdir lib bin sbin k3os dev proc etc sys
-    mount --bind /bin bin
-    mount --bind /sbin sbin
-    mount --bind /run/k3os/iso/k3os k3os
-    mount --bind /dev dev
-    mount --bind /proc proc
-    mount --bind /etc etc
-    mount -r --rbind /lib lib
-    mount -r --rbind /sys sys
-    chroot . /bin/bash <<"EOF"
-    # invoke k3s to set up data dir
-    k3s agent --no-flannel &>/dev/null || true
-    # start containerd
-    /var/lib/rancher/k3s/data/current/bin/containerd \
-    -c /var/lib/rancher/k3s/agent/etc/containerd/config.toml \
-    -a /run/k3s/containerd/containerd.sock \
-    --state /run/k3s/containerd \
-    --root /var/lib/rancher/k3s/agent/containerd &>/dev/null &
+      echo "Decompressing container images"
+      zstd -d --rm "${root_path}/${offline_image_path}.zst" -o "${root_path}/${offline_image_path}" > /dev/null
+      cd ${root_path}
+      mkdir lib bin sbin k3os dev proc etc sys
+      mount --bind /bin bin
+      mount --bind /sbin sbin
+      mount --bind /run/k3os/iso/k3os k3os
+      mount --bind /dev dev
+      mount --bind /proc proc
+      mount --bind /etc etc
+      mount -r --rbind /lib lib
+      mount -r --rbind /sys sys
+      echo "Loading images. This may take a few minutes"
+      chroot . /bin/bash <<"EOF"
+      # invoke k3s to set up data dir
+      k3s agent --no-flannel &>/dev/null || true
+      # start containerd
+      /var/lib/rancher/k3s/data/current/bin/containerd \
+      -c /var/lib/rancher/k3s/agent/etc/containerd/config.toml \
+      -a /run/k3s/containerd/containerd.sock \
+      --state /run/k3s/containerd \
+      --root /var/lib/rancher/k3s/agent/containerd &>/dev/null &
 
-    #wait for containerd to be ready
-    until ctr --connect-timeout 1s version>/dev/null
-    do
-      sleep 1
-    done
-    # import images
-    ctr -n k8s.io images import /var/lib/rancher/k3s/agent/images/harvester*
-    rm /var/lib/rancher/k3s/agent/images/harvester*
-    # stop containerd
-    pkill containerd
-    exit
+      #wait for containerd to be ready
+      until ctr --connect-timeout 1s version>/dev/null
+      do
+        sleep 1
+      done
+      # import images
+      ctr -n k8s.io images import /var/lib/rancher/k3s/agent/images/harvester*
+      rm /var/lib/rancher/k3s/agent/images/harvester*
+      # stop containerd
+      pkill containerd
+      exit
 EOF
-    sleep 5
-    #cleanup
-    umount bin sbin k3os dev proc etc
-    mount --make-rslave lib
-    mount --make-rslave sys
-    umount -R lib
-    umount -R sys
-    rm -r lib bin sbin k3os dev proc etc sys
+      sleep 5
+      #cleanup
+      umount bin sbin k3os dev proc etc
+      mount --make-rslave lib
+      mount --make-rslave sys
+      umount -R lib
+      umount -R sys
+      rm -r lib bin sbin k3os dev proc etc sys
+    fi
 }
 
 install_grub()

--- a/k3os/scripts/images
+++ b/k3os/scripts/images
@@ -5,6 +5,11 @@ if [ "$ARCH" != "arm" ]; then
     export DOCKER_BUILDKIT=1
 fi
 
+    PROXY_OPTS=
+[ -z "$http_proxy" ] || PROXY_OPTS="$PROXY_OPTS --build-arg http_proxy=$http_proxy"
+[ -z "$https_proxy" ] || PROXY_OPTS="$PROXY_OPTS --build-arg https_proxy=$https_proxy"
+[ -z "$no_proxy" ] || PROXY_OPTS="$PROXY_OPTS --build-arg no_proxy=$no_proxy"
+
 build_all()
 {
     if [ "$#" = 0 ]; then
@@ -28,7 +33,7 @@ build_all()
         if [ -e root ]; then
             ROOT=$(readlink -f root)
         fi
-        DOCKER_BUILDKIT=1 docker build --build-arg TAG=$TAG --build-arg VERSION=${VERSION} --build-arg HARVESTER_VERSION=${HARVESTER_VERSION} --build-arg REPO=${REPO} --build-arg ARCH=${ARCH} -f $(pwd)/Dockerfile -t $FULL_IMAGE $ROOT
+        DOCKER_BUILDKIT=1 docker build ${PROXY_OPTS} --build-arg TAG=$TAG --build-arg VERSION=${VERSION} --build-arg HARVESTER_VERSION=${HARVESTER_VERSION} --build-arg REPO=${REPO} --build-arg ARCH=${ARCH} -f $(pwd)/Dockerfile -t $FULL_IMAGE $ROOT
         cd ..
     done
 }

--- a/scripts/build
+++ b/scripts/build
@@ -9,7 +9,6 @@ echo "Start building ISO"
 
 K3S_VERSION=v1.20.4+k3s1
 K3S_IMAGE_URL=https://raw.githubusercontent.com/rancher/k3s/${K3S_VERSION}/scripts/airgap/image-list.txt
-OFFLINE_BUILD="1"
 
 # Prepare Harvester chart
 mkdir -p k3os/images/70-iso/charts
@@ -58,7 +57,7 @@ awk -F ':' '{if($2==""){print $1":latest"}else{print $0}}' ${image_list_file} >"
 awk -F '/' '{if(NF==3){print $0} else if(NF==2){print "docker.io/"$0}else if(NF=1){print "docker.io/library/"$0}}' "${image_list_file}.tmp" > ${image_list_file}
 
 output_image_tar_file="k3os/images/70-iso/harvester-images.tar"
-if [ -n "${OFFLINE_BUILD}" ] && [ ! -f $output_image_tar_file.zst ]; then
+if [ -z "${HARVESTER_INSTALLER_OFFLINE_BUILD}" ] && [ ! -f $output_image_tar_file.zst ]; then
   images=$(cat "${image_list_file}")
   echo "${images}" | while read -r image
   do


### PR DESCRIPTION
Support configure http_proxy and exclude offline images by env to speed up local  build.

Docker Desktop eg:
```bash
export http_proxy=http://host.docker.internal:1087
export https_proxy=http://host.docker.internal:1087
export HARVESTER_INSTALLER_OFFLINE_BUILD=1
make
```

