### PR TITLE
K3OS: support various TTYs

### DIFF
--- a/k3os/overlay/bin/start-harvester-console.sh
+++ b/k3os/overlay/bin/start-harvester-console.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+source /opt/harvester-mode
+
+export TTY=$(tty)
+export TERM="linux"
+
+# Set a default window size for un-attached terminals like serial consoles
+MIN_ROWS=24
+MIN_COLS=80
+read ROWS COLS <<< $(/usr/bin/stty -F ${TTY} size)
+if [ $ROWS -lt $MIN_ROWS ] || [ $COLS -lt $MIN_COLS ]; then
+    /usr/bin/stty -F "${TTY}" rows "${MIN_ROWS}" cols "${MIN_COLS}"
+fi
+
+harvester-console
+/bin/bash --login

--- a/k3os/overlay/libexec/k3os/boot
+++ b/k3os/overlay/libexec/k3os/boot
@@ -2,29 +2,19 @@
 
 setup_ttys()
 {
-    for i in 2 3 4 5 6; do
+    for i in 1 2 3 4 5 6; do
         if [ -e /dev/tty${i} ]; then
             echo 'tty'$i'::respawn:/sbin/getty 38400 tty'$i >> /etc/inittab
             echo tty$i >> /etc/securetty
         fi
     done
 
-    if [ "$K3OS_MODE" != "local" ]; then
-        echo 'tty1::respawn:/sbin/getty 38400 tty1' >> /etc/inittab
-        echo tty1 >> /etc/securetty
+    HVST_CONSOLE_ENV=/opt/harvester-mode
+    mkdir -p /opt
+    if [ "$K3OS_MODE" = "local" ]; then
+        echo "export HARVESTER_DASHBOARD=true" > ${HVST_CONSOLE_ENV}
     else
-        mkdir -p /opt
-        cat > /opt/start_harvester_console.sh << EOF
-#!/bin/bash
-
-export HARVESTER_DASHBOARD=true
-export TTY=$(tty)
-harvester-console
-/bin/bash --login
-EOF
-        chmod +x /opt/start_harvester_console.sh
-        echo 'tty1::respawn:/sbin/getty -l /opt/start_harvester_console.sh -n 38400 tty1' >> /etc/inittab
-        echo tty1 >> /etc/securetty
+        echo "export HARVESTER_DASHBOARD=false" > ${HVST_CONSOLE_ENV}
     fi
 
     for x in $(cat /proc/cmdline); do
@@ -34,14 +24,36 @@ EOF
             ;;
         console=*)
             CONSOLE_SPEC=${x#console=}
-            IFS=, read TTY BAUDRATE _ <<<"${CONSOLE_SPEC},9600"
+            IFS=, read TTY BAUDRATE _ <<<"${CONSOLE_SPEC}"
+            if [ -n "${BAUDRATE}" ]; then
+                # remove "n8" from 115200n8, getty doesn't like it.
+                BAUDRATE=${BAUDRATE%n*}
+                BAUDRATE=${BAUDRATE%o*}
+                BAUDRATE=${BAUDRATE%e*}
+            else
+                if echo ${TTY} | grep -q -E "^tty[1-6]$"; then
+                    BAUDRATE="38400"
+                else
+                    BAUDRATE="9600"
+                fi
+            fi
+
             if [ -e /dev/${TTY} ] && ! grep -q "^${TTY}::" /etc/inittab; then
-                echo "${TTY}::respawn:/sbin/getty -L ${BAUDRATE} ${TTY} vt100" >> /etc/inittab
+                echo "${TTY}::respawn:/sbin/getty -L ${BAUDRATE} ${TTY}" >> /etc/inittab
                 echo ${TTY} >> /etc/securetty
             fi
+
+            HVST_TTY="${TTY}"
+            HVST_BAUDRATE="${BAUDRATE}"
             ;;
         esac
     done
+
+    # Display installer on the last TTY defined in the `console=` parameters
+    if [ -n "${HVST_TTY}" -a -n "${HVST_BAUDRATE}" ]; then
+        sed -i "/^${HVST_TTY}::/d" /etc/inittab
+        echo "${HVST_TTY}::respawn:/sbin/getty -l /usr/bin/start-harvester-console.sh -n ${HVST_BAUDRATE} ${HVST_TTY}" >> /etc/inittab
+    fi
 }
 
 setup_sudoers()

--- a/k3os/pkg/cc/apply.go
+++ b/k3os/pkg/cc/apply.go
@@ -31,7 +31,6 @@ func RunApply(cfg *config.CloudConfig) error {
 		ApplyWriteFiles,
 		ApplyEnvironment,
 		ApplyRuncmd,
-		ApplyInstall,
 		ApplyK3SInstall,
 	)
 }


### PR DESCRIPTION
- Use getty to spawn the harvester-installer. By doing this, we can define a
  default window dimension. This prevents installer cui initialization
  failure on a serial console.
- Use the last `console=` kernel parameter value as the TTY which the installer
  and Dashboard should be displayed on.
- Do not run `k3os install` in ccapply.

Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>

**Relate issue**
https://github.com/rancher/harvester/issues/485