### PR TITLE
Fix mismatching chart version

### DIFF
--- a/k3os/images/70-iso/Dockerfile
+++ b/k3os/images/70-iso/Dockerfile
@@ -27,6 +27,7 @@ RUN mkdir -p /usr/src/iso/var/lib/rancher/k3s/agent/images \
     /usr/src/iso/var/lib/rancher/k3s/server/static/charts \
     /usr/src/iso/var/lib/rancher/k3s/server/manifests
 COPY charts/* /usr/src/iso/var/lib/rancher/k3s/server/static/charts
+COPY manifests/* /usr/src/iso/var/lib/rancher/k3s/server/manifests
 RUN --mount=type=bind,source=/,target=/ctx cp /ctx/harvester-images.tar.zst \
     /usr/src/iso/var/lib/rancher/k3s/agent/images &>/dev/null || true
 

--- a/manifests/harvester.yaml
+++ b/manifests/harvester.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: harvester-system
+---
+apiVersion: helm.cattle.io/v1
+kind: HelmChart
+metadata:
+  name: harvester
+  namespace: kube-system
+spec:
+  chart: https://%{KUBERNETES_API}%/static/charts/$HARVESTER_CHART
+  targetNamespace: harvester-system
+  set:
+    containers.apiserver.authMode: "localUser"
+    multus.enabled: "true"
+    longhorn.enabled: "true"
+    longhorn.defaultSettings.taintToleration: "kubevirt.io/drain:NoSchedule"
+    minio.persistence.storageClass: "longhorn"
+    containers.apiserver.image.imagePullPolicy: "IfNotPresent"
+    harvester-network-controller.image.pullPolicy: "IfNotPresent"
+    service.harvester.type: "NodePort"
+    service.harvester.httpsNodePort: 30443

--- a/pkg/console/testdata/create-cc.yaml
+++ b/pkg/console/testdata/create-cc.yaml
@@ -2,33 +2,6 @@ ssh_authorized_keys:
 - ssh-rsa AAAAB3NzaC1yc2EAAAADAQAB...
 - github:username
 hostname: myhost
-writeFiles:
-- content: |
-    apiVersion: v1
-    kind: Namespace
-    metadata:
-      name: harvester-system
-    ---
-    apiVersion: helm.cattle.io/v1
-    kind: HelmChart
-    metadata:
-      name: harvester
-      namespace: kube-system
-    spec:
-      chart: https://%{KUBERNETES_API}%/static/charts/harvester-0.1.0.tgz
-      targetNamespace: harvester-system
-      set:
-        minio.persistence.storageClass: "longhorn"
-        containers.apiserver.image.imagePullPolicy: "IfNotPresent"
-        harvester-network-controller.image.pullPolicy: "IfNotPresent"
-        service.harvester.type: "LoadBalancer"
-        containers.apiserver.authMode: "localUser"
-        multus.enabled: "true"
-        longhorn.enabled: "true"
-  encoding: ""
-  owner: root
-  path: /var/lib/rancher/k3s/server/manifests/harvester.yaml
-  permissions: "0600"
 k3os:
   modules:
   - kvm

--- a/pkg/console/util_test.go
+++ b/pkg/console/util_test.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -55,15 +54,6 @@ func TestGetSSHKeysFromURL(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestGetHarvesterManifestContent(t *testing.T) {
-	d := map[string]string{
-		"a": "b",
-		"b": "\"c\"",
-	}
-	res := getHarvesterManifestContent(d)
-	t.Log(res)
 }
 
 func TestGetHStatus(t *testing.T) {
@@ -176,14 +166,6 @@ func TestToCloudConfig(t *testing.T) {
 				t.Fatalf("fail to load %q", testCase.resultFile)
 			}
 			cloudConfig := toCloudConfig(cfg)
-
-			if cfg.Mode == modeCreate {
-				// line order in the write file content is random, do our best
-				content := cloudConfig.WriteFiles[0].Content
-				assert.True(t, strings.HasPrefix(content, "apiVersion: v1"))
-				cloudConfig.WriteFiles[0].Content = ""
-				expected.WriteFiles[0].Content = ""
-			}
 
 			assert.Equal(t, expected, cloudConfig)
 		})

--- a/scripts/build
+++ b/scripts/build
@@ -20,6 +20,11 @@ fi
 harvester_chart_path=${harvester_path}/deploy/charts/harvester
 helm package ${harvester_chart_path} -d k3os/images/70-iso/charts
 
+# Prepare Harvester manifests
+HARVESTER_CHART=$(ls k3os/images/70-iso/charts/harvester* | xargs basename)
+sed -i 's/$HARVESTER_CHART/'$HARVESTER_CHART'/' manifests/harvester.yaml
+cp -r manifests k3os/images/70-iso/
+
 # Offline docker images
 # get image list from harvester chart's values file
 image_list_file='image-list.txt'


### PR DESCRIPTION
package manifests and remove writeFiles configurations

Problem:
1. chart version mismatches the chart manifest spec
2. WriteFiles session is mounted read-only and inappropriate for upgrade.


Issue: https://github.com/rancher/harvester/issues/509