### PR TITLE
Add retry to ping serverURL

### DIFF
--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -96,10 +96,9 @@ func (c *Console) setContentByName(name string, content string) error {
 func (c *Console) CloseElement(name string) {
 	v, err := c.GetElement(name)
 	if err != nil {
-		// ignore not found error
 		return
 	}
-	if err = v.Close(); err != nil {
+	if err = v.Close(); err != nil && err != gocui.ErrUnknownView {
 		logrus.Error(err)
 	}
 }

--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -271,8 +271,7 @@ func addServerURLPanel(c *Console) error {
 			spinner := NewSpinner(c.Gui, spinnerPanel, fmt.Sprintf("Checking %q...", pingServerURL))
 			spinner.Start()
 			go func(g *gocui.Gui) {
-				err := validateInsecureURL(pingServerURL)
-				if err != nil {
+				if err = validatePingServerURL(pingServerURL); err != nil {
 					spinner.Stop(true, err.Error())
 					g.Update(func(g *gocui.Gui) error {
 						return showNext(c, serverURLPanel)


### PR DESCRIPTION
**Problem**
1. After network page closed, some `unknow view` error show on `/var/log/console.log`
2. After network page closed, network will be not available a few seconds, ping serverURL will be fail.
https://github.com/rancher/harvester/issues/490#issuecomment-792701862

**Solution**
1. Check error msg， if error msg is `unknow view`, ignore it
2. Add retry warp to `getURL`, set retrynum=3, retryinterval=2 to ping serverURL


**Related issue**
rancher/harvester#490

