### PR TITLE
publish latest artifacts

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -15,6 +15,23 @@ steps:
   - name: docker
     path: /var/run/docker.sock
 
+- name: publish-head
+  image: plugins/gcs
+  settings:
+    acl:
+      - allUsers:READER
+    cache_control: "public,no-cache,proxy-revalidate"
+    source: dist/artifacts
+    target: releases.rancher.com/harvester/${DRONE_BRANCH}
+    token:
+      from_secret: google_auth_key
+  when:
+    ref:
+      include:
+        - "refs/heads/master"
+    event:
+      - push
+
 volumes:
 - name: docker
   host:


### PR DESCRIPTION
Publish the latest artifacts to `releases.rancher.com` given that ISO image exceeds the Github file size limit.