### PR TITLE
Allow specifying webhooks to get installer event notifications

### DIFF
--- a/k3os/images/20-rootfs/Dockerfile
+++ b/k3os/images/20-rootfs/Dockerfile
@@ -99,6 +99,7 @@ RUN ln -s k3s /usr/src/image/sbin/ctr
 RUN ln -s /k3os/system/k3os/current/k3os /usr/src/image/sbin/harvester-console
 
 COPY install.sh /usr/src/image/libexec/k3os/install
+COPY shutdown.sh /usr/src/image/libexec/k3os/shutdown
 RUN sed -i -e "s/%VERSION%/${VERSION}/g" -e "s/%HARVESTER_VERSION%/${HARVESTER_VERSION}/g" -e "s/%ARCH%/${ARCH}/g" /usr/src/image/lib/os-release
 RUN mkdir -p /output && \
     mksquashfs /usr/src/image /output/rootfs.squashfs

--- a/k3os/install.sh
+++ b/k3os/install.sh
@@ -396,11 +396,3 @@ if [ -n "$INTERACTIVE" ]; then
     exit 0
 fi
 
-if [ "$K3OS_INSTALL_POWER_OFF" = true ] || grep -q 'k3os.install.power_off=true' /proc/cmdline; then
-    poweroff -f
-else
-    echo " * Installation completed"
-    echo " * Rebooting system in 5 seconds"
-    sleep 5
-    reboot -f
-fi

--- a/k3os/shutdown.sh
+++ b/k3os/shutdown.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+if [ "$K3OS_INSTALL_POWER_OFF" = true ] || grep -q 'k3os.install.power_off=true' /proc/cmdline; then
+    poweroff -f
+else
+    echo " * Installation completed"
+    echo " * Rebooting system in 5 seconds"
+    sleep 5
+    reboot -f
+fi

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,6 +19,21 @@ type Network struct {
 	DNSNameservers []string `json:"dnsNameservers,omitempty"`
 }
 
+type HTTPBasicAuth struct {
+	User     string `json:"user,omitempty"`
+	Password string `json:"password,omitempty"`
+}
+
+type Webhook struct {
+	Event     string              `json:"event,omitempty"`
+	Method    string              `json:"method,omitempty"`
+	Headers   map[string][]string `json:"headers,omitempty"`
+	URL       string              `json:"url,omitempty"`
+	Payload   string              `json:"payload,omitempty"`
+	Insecure  bool                `json:"insecure,omitempty"`
+	BasicAuth HTTPBasicAuth       `json:"basicAuth,omitempty"`
+}
+
 type Install struct {
 	Automatic     bool      `json:"automatic,omitempty"`
 	Mode          string    `json:"mode,omitempty"`
@@ -34,6 +49,8 @@ type Install struct {
 	NoFormat  bool   `json:"noFormat,omitempty"`
 	Debug     bool   `json:"debug,omitempty"`
 	TTY       string `json:"tty,omitempty"`
+
+	Webhooks []Webhook `json:"webhooks,omitempty"`
 }
 
 type Wifi struct {

--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -1184,7 +1184,12 @@ func addInstallPanel(c *Console) error {
 				printToPanel(c.Gui, err.Error(), installPanel)
 				return
 			}
-			doInstall(c.Gui, toCloudConfig(c.config))
+
+			webhooks, err := PrepareWebhooks(c.config.Webhooks, getWebhookContext(c.config))
+			if err != nil {
+				printToPanel(c.Gui, fmt.Sprintf("invalid webhook: %s", err), installPanel)
+			}
+			doInstall(c.Gui, toCloudConfig(c.config), webhooks)
 		}()
 		return c.setContentByName(footerPanel, "")
 	}

--- a/pkg/console/webhooks.go
+++ b/pkg/console/webhooks.go
@@ -1,0 +1,263 @@
+package console
+
+import (
+	"bytes"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/rancher/harvester-installer/pkg/config"
+	"github.com/rancher/harvester-installer/pkg/util"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	WebhookMaxRetries = 3
+)
+
+type RenderedWebhook struct {
+	config.Webhook
+	RenderedURL     string
+	RenderedPayload string
+	Valid           bool
+}
+
+type RendererWebhooks []RenderedWebhook
+
+const (
+	EventInstallStarted  = "STARTED"
+	EventInstallSuceeded = "SUCCEEDED"
+	EventInstallFailed   = "FAILED"
+)
+
+func IsValidEvent(event string) bool {
+	events := []string{
+		EventInstallStarted,
+		EventInstallSuceeded,
+		EventInstallFailed,
+	}
+	return util.StringSliceContains(events, event)
+}
+
+func IsValidHTTPMethod(method string) bool {
+	methods := []string{
+		http.MethodGet,
+		http.MethodHead,
+		http.MethodPost,
+		http.MethodPut,
+		http.MethodPatch,
+		http.MethodDelete,
+		http.MethodConnect,
+		http.MethodOptions,
+		http.MethodTrace,
+	}
+	return util.StringSliceContains(methods, method)
+}
+
+func (p *RenderedWebhook) Handle() error {
+	logrus.Debugf("handle webhook: %+v", p)
+
+	doHTTPReq := func() error {
+		c := http.Client{
+			Timeout: defaultHTTPTimeout,
+		}
+
+		if p.Webhook.Insecure {
+			c.Transport = &http.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: true,
+				},
+			}
+		}
+
+		var body io.Reader
+		if p.RenderedPayload != "" {
+			body = strings.NewReader(p.RenderedPayload)
+		}
+
+		req, err := http.NewRequest(p.Webhook.Method, p.RenderedURL, body)
+		if err != nil {
+			return err
+		}
+
+		if p.BasicAuth.User != "" && p.BasicAuth.Password != "" {
+			req.SetBasicAuth(p.BasicAuth.User, p.BasicAuth.Password)
+		}
+
+		for k, vv := range p.Webhook.Headers {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
+
+		resp, err := c.Do(req)
+		if err != nil {
+			return err
+		}
+
+		if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+			return fmt.Errorf("got %d status code from %s", resp.StatusCode, p.RenderedURL)
+		}
+		return nil
+	}
+
+	// retries on timeout
+	retries := 0
+	var retryErr error
+	for retries <= WebhookMaxRetries {
+		err := doHTTPReq()
+		switch e := err.(type) {
+		case *url.Error:
+			if e.Timeout() {
+				time.Sleep(5 * time.Second)
+				retries++
+				retryErr = err
+				continue
+			}
+		}
+		return err
+	}
+	return retryErr
+}
+
+func dupHeaders(h map[string][]string) map[string][]string {
+	if h == nil {
+		return nil
+	}
+	m := make(map[string][]string)
+	for k, v := range h {
+		m[k] = util.DupStrings(v)
+	}
+	return m
+}
+
+func prepareWebhook(h config.Webhook, context map[string]string) (*RenderedWebhook, error) {
+	p := &RenderedWebhook{
+		Webhook: config.Webhook{
+			Event:    h.Event,
+			Method:   strings.ToUpper(h.Method),
+			Headers:  dupHeaders(h.Headers),
+			URL:      h.URL,
+			Payload:  h.Payload,
+			Insecure: h.Insecure,
+			BasicAuth: config.HTTPBasicAuth{
+				User:     h.BasicAuth.User,
+				Password: h.BasicAuth.Password,
+			},
+		},
+	}
+
+	if !IsValidEvent(p.Webhook.Event) {
+		return nil, errors.Errorf("unknown install event: %s", p.Webhook.Event)
+	}
+	if !IsValidHTTPMethod(p.Webhook.Method) {
+		return nil, errors.Errorf("unknown HTTP method: %s", p.Webhook.Method)
+	}
+
+	// render URL
+	tmplOption := "missingkey=zero"
+	bs := bytes.NewBufferString("")
+	tmpl, err := template.New("URL").Option(tmplOption).Parse(p.Webhook.URL)
+	if err != nil {
+		return nil, err
+	}
+	err = tmpl.Execute(bs, context)
+	if err != nil {
+		return nil, err
+	}
+	p.RenderedURL = bs.String()
+
+	// render payload
+	bs.Reset()
+	tmpl, err = template.New("Payload").Option(tmplOption).Parse(p.Webhook.Payload)
+	if err != nil {
+		return nil, err
+	}
+	err = tmpl.Execute(bs, context)
+	if err != nil {
+		return nil, err
+	}
+	p.RenderedPayload = bs.String()
+
+	return p, nil
+}
+
+func PrepareWebhooks(hooks []config.Webhook, context map[string]string) (RendererWebhooks, error) {
+	var result RendererWebhooks
+	for _, h := range hooks {
+		logrus.Debugf("preparing webhook %+v", h)
+		p, err := prepareWebhook(h, context)
+		if err != nil {
+			msg := fmt.Sprintf("fail to prepare webhook %+v: %s", h, err)
+			logrus.Error(msg)
+			return nil, errors.New(msg)
+		}
+		p.Valid = true
+		logrus.Debugf("rendered webhook %+v", *p)
+		result = append(result, *p)
+	}
+	return result, nil
+}
+
+func (hooks RendererWebhooks) Handle(event string) {
+	logrus.Infof("handle webhooks for event %s", event)
+	for _, h := range hooks {
+		if event != h.Webhook.Event {
+			continue
+		}
+		if err := h.Handle(); err != nil {
+			logrus.Errorf("fail to handle webhook: %s", err)
+			return
+		}
+	}
+}
+
+func getIPAddr(iface *net.Interface, v6 bool) string {
+	addrs, err := iface.Addrs()
+	if err == nil {
+		for _, addr := range addrs {
+			var ip net.IP
+			switch t := addr.(type) {
+			case *net.IPNet:
+				ip = t.IP
+			case *net.IPAddr:
+				ip = t.IP
+			}
+
+			// looks like IPv4 address is represented as IPv6 by default
+			if ip != nil && len(ip) == net.IPv6len {
+				r := ip.To4()
+				if r != nil && !v6 {
+					return r.String()
+				}
+				if r == nil && v6 {
+					return ip.String()
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func getWebhookContext(cfg *config.HarvesterConfig) map[string]string {
+	// Hostname
+	m := map[string]string{
+		"Hostname": cfg.Hostname,
+	}
+
+	// MAC address and IP addresses
+	if iface, err := net.InterfaceByName(cfg.Install.MgmtInterface); err == nil {
+		m["MACAddr"] = iface.HardwareAddr.String()
+		m["IPAddrV4"] = getIPAddr(iface, false)
+		m["IPAddrV6"] = getIPAddr(iface, true)
+	}
+	logrus.Debugf("webhook context %+v", m)
+	return m
+}

--- a/pkg/console/webhooks_test.go
+++ b/pkg/console/webhooks_test.go
@@ -1,0 +1,182 @@
+package console
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/rancher/harvester-installer/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseWebhook(t *testing.T) {
+	tests := []struct {
+		name          string
+		unparsed      config.Webhook
+		context       map[string]string
+		parsedURL     string
+		parsedPayload string
+		errorString   string
+	}{
+		{
+			name: "valid",
+			unparsed: config.Webhook{
+				Event:  "SUCCEEDED",
+				Method: "get",
+				Headers: map[string][]string{
+					"Content-Type": {"application/json; charset=UTF-8"},
+				},
+				URL:     "http://10.100.0.10/cblr/svc/op/nopxe/system/{{.Hostname}}/{{.Unknown}}",
+				Payload: `{"hostname": "{{.Hostname}}"}`,
+			},
+			context: map[string]string{
+				"Hostname": "node1",
+			},
+			parsedURL:     "http://10.100.0.10/cblr/svc/op/nopxe/system/node1/",
+			parsedPayload: `{"hostname": "node1"}`,
+		},
+		{
+			name: "invalid event",
+			unparsed: config.Webhook{
+				Event:  "XXX",
+				Method: "GET",
+				URL:    "http://somewhere.com",
+			},
+			errorString: "unknown install event: XXX",
+		},
+		{
+			name: "invalid HTTP method",
+			unparsed: config.Webhook{
+				Event:  "STARTED",
+				Method: "PUNCH",
+				URL:    "http://somewhere.com",
+			},
+			errorString: "unknown HTTP method: PUNCH",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, err := prepareWebhook(tt.unparsed, tt.context)
+			if tt.errorString != "" {
+				assert.EqualError(t, err, tt.errorString)
+			} else {
+				assert.Equal(t, tt.parsedURL, p.RenderedURL)
+				assert.Equal(t, tt.parsedPayload, p.RenderedPayload)
+				assert.Equal(t, nil, err)
+			}
+		})
+	}
+}
+
+func TestParsedWebhook_Send(t *testing.T) {
+	type fields struct {
+		TLS             bool
+		Webhook         config.Webhook
+		RenderedURL     string
+		RenderedPayload string
+	}
+	type RequestRecorder struct {
+		Method  string
+		Body    string
+		Headers map[string][]string
+		Handled bool
+	}
+
+	tests := []struct {
+		name        string
+		fields      fields
+		wantMethod  string
+		wantHeaders map[string][]string
+		wantBody    string
+	}{
+		{
+			name: "get a url",
+			fields: fields{
+				Webhook: config.Webhook{Method: "GET"},
+			},
+			wantMethod: "GET",
+		},
+		{
+			name: "get a url from a TLS server",
+			fields: fields{
+				TLS:     true,
+				Webhook: config.Webhook{Method: "GET", Insecure: true},
+			},
+			wantMethod: "GET",
+		},
+		{
+			name: "get a url with basic auth",
+			fields: fields{
+				Webhook: config.Webhook{
+					Method: "GET",
+					BasicAuth: config.HTTPBasicAuth{
+						User:     "aaa",
+						Password: "bbb",
+					},
+				},
+			},
+			wantMethod: "GET",
+			wantHeaders: map[string][]string{
+				"Authorization": {"Basic YWFhOmJiYg=="},
+			},
+		},
+		{
+			name: "put a body",
+			fields: fields{
+				Webhook: config.Webhook{
+					Method: "PUT",
+					Headers: map[string][]string{
+						"Content-Type": {"application/json; charset=utf-8"},
+						"X-Yyy":        {"a", "b"},
+					},
+				},
+				RenderedPayload: "data",
+			},
+			wantMethod: "PUT",
+			wantHeaders: map[string][]string{
+				"Content-Type":   {"application/json; charset=utf-8"},
+				"Content-Length": {"4"},
+				"X-Yyy":          {"a", "b"},
+			},
+			wantBody: "data",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := RequestRecorder{}
+			newTestServer := httptest.NewServer
+			if tt.fields.TLS {
+				newTestServer = httptest.NewTLSServer
+			}
+			ts := newTestServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				recorder.Method = r.Method
+				recorder.Headers = dupHeaders(r.Header)
+				defer r.Body.Close()
+				body, err := ioutil.ReadAll(r.Body)
+				if err != nil {
+					return
+				}
+				recorder.Body = string(body)
+				recorder.Handled = true
+			}))
+			defer ts.Close()
+
+			p := &RenderedWebhook{
+				Webhook:         tt.fields.Webhook,
+				RenderedURL:     ts.URL,
+				RenderedPayload: tt.fields.RenderedPayload,
+			}
+			p.Handle()
+			assert.Equal(t, true, recorder.Handled)
+			assert.Equal(t, tt.wantMethod, recorder.Method)
+			for k, vv := range tt.wantHeaders {
+				assert.Contains(t, recorder.Headers, k)
+				for _, v := range vv {
+					assert.Contains(t, recorder.Headers[k], v)
+				}
+			}
+			assert.Equal(t, tt.wantBody, recorder.Body)
+		})
+	}
+}

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -1,0 +1,30 @@
+package util
+
+func StringSliceContains(sSlice []string, s string) bool {
+	for _, target := range sSlice {
+		if target == s {
+			return true
+		}
+	}
+	return false
+}
+
+func DupStrings(src []string) []string {
+	if src == nil {
+		return nil
+	}
+	s := make([]string, len(src))
+	copy(s, src)
+	return s
+}
+
+func DupStringMap(src map[string]string) map[string]string {
+	if src == nil {
+		return nil
+	}
+	m := make(map[string]string)
+	for k, v := range src {
+		m[k] = v
+	}
+	return m
+}


### PR DESCRIPTION

**Relate issue**
https://github.com/rancher/harvester/issues/469

With this change, the user can add webhooks in the config and the installer will send HTTP
requests to custom URLs on some predefined events.

The user can add webhooks under the `install` key of the [harvester configuration file](https://github.com/rancher/harvester/blob/fef31431c43b3abcde96c8b4209e6cd27a10048d/docs/harvester-configuration.md):

The following is a configuration example:

```yaml
install:
  webhooks:
    - event: SUCCEEDED
      method: GET
      url: http://10.100.0.100/cblr/svc/op/nopxe/system/{{.Hostname}}
    - event: STARTED
      method: GET
      url: https://10.100.0.100/started/{{.Hostname}}
      insecure: true
      basicAuth:
        user: admin
        password: p@assword
    - event: FAILED
      method: POST
      url: http://10.100.0.100/record
      headers:
        Content-Type:
           - 'application/json; charset=utf-8'
      payload: |
        {
          "host": "{{.Hostname}}",
          "device": "hd"
        }
```


Explanation of the fields:

* `event`: Event type to trigger HTTP action on the webhook
  * `STARTED`: The installer just begins to perform installation.
  * `SUCCEEDED`: The installation completes without errors.
  * `FAILED`: The installation is failed.

  Example:

  ```yaml
  event: SUCCEEDED
  ```
- `method`: [HTTP method](https://golang.or.g/pkg/net/http/#pkg-constants)

  Example:

  ```yaml
  method: GET
  ```

- `url`*: The URL to send the HTTP request.

  ```yaml
  url: http://mycompany.com
  ```
- `insecure`:  Do not verify server's certificate if `true`. Default is `false`.

  Example:

  ```yaml
  insecure: true
  ```

- `basicAuth`: Use 'Basic' HTTP Authentication.

  Example: 
  
  ```yaml
  basicAuth:
    user: admin
    password: p@ssword
  ```

- `headers`: Include custom headers in the HTTP requests.

  Example: 
  
  ```yaml
  headers:
    Content-Type:
      - 'application/json; charset=utf-8'
  ```

  Above configuration will includes `Content-Type: application/json; charset=utf-8` in the HTTP request.

  > **NOTE**: Headers like `Content-Length` are automatically included.

- `payload`*: The payload data to be sent with the request.

  Example: 
  
  ```yaml
  payload: |
    {
      "host": "{{.Hostname}}",
      "device": "hd"
    }
  ```

  > **NOTE**: The user might need to set the correct `Content-Type` header with the `headers` configuration to make the server accept the request.

**\*** The values for `url` and `payload` can be written in Go template, the following variables will be substituted with appropriate values of the node that is being installed:

- `Hostname`: the hostname of the node.
- `MACAddr`: the MAC address of the management interface
- `IPAddrV4`: the IPv4 address of the management interface
- `IPAddrV6`: the IPv6 address of the management interface


**Additional information**
- The installer can send multiple requests for a single event. But if one of them fails, the remaining requests will not be sent.
- The installer will retry 3 times with a 5 seconds-sleep if the request is timed out.

