### PR TITLE
Fix TTY permission issue

### DIFF
--- a/k3os/overlay/bin/start-harvester-console.sh
+++ b/k3os/overlay/bin/start-harvester-console.sh
@@ -2,7 +2,7 @@
 
 source /opt/harvester-mode
 
-export TTY=$(tty)
+export TTY="/dev/console"
 export TERM="linux"
 
 # Set a default window size for un-attached terminals like serial consoles


### PR DESCRIPTION
On platform like Equinix Metal, the `/dev/ttyS1` device can't be open by
the installer. Using `/dev/console` as a workaround.

Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>

**Related Issue**
https://github.com/rancher/harvester/issues/485#issuecomment-799987099

A sample iPXE script to test: https://raw.githubusercontent.com/bk201/hvst-ipxe/test/equinix/ipxe-create
