### PR TITLE
Add rancher deployment

### DIFF
--- a/manifests/cert-manager.yaml
+++ b/manifests/cert-manager.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager
+---
+apiVersion: helm.cattle.io/v1
+kind: HelmChart
+metadata:
+  name: cert-manager
+  namespace: kube-system
+spec:
+  chart: https://%{KUBERNETES_API}%/static/charts/$CERT_MANAGER_CHART
+  targetNamespace: cert-manager
+  set:
+    installCRDs: "true"

--- a/manifests/harvester.yaml
+++ b/manifests/harvester.yaml
@@ -12,7 +12,7 @@ spec:
   chart: https://%{KUBERNETES_API}%/static/charts/$HARVESTER_CHART
   targetNamespace: harvester-system
   set:
-    containers.apiserver.authMode: "localUser"
+    containers.apiserver.authMode: "rancher"
     multus.enabled: "true"
     longhorn.enabled: "true"
     longhorn.defaultSettings.taintToleration: "kubevirt.io/drain:NoSchedule"
@@ -21,3 +21,4 @@ spec:
     harvester-network-controller.image.pullPolicy: "IfNotPresent"
     service.harvester.type: "NodePort"
     service.harvester.httpsNodePort: 30443
+    rancherEmbedded: "true"

--- a/manifests/rancher.yaml
+++ b/manifests/rancher.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cattle-system
+---
+apiVersion: helm.cattle.io/v1
+kind: HelmChart
+metadata:
+  name: rancher
+  namespace: kube-system
+spec:
+  chart: https://%{KUBERNETES_API}%/static/charts/$RANCHER_CHART
+  targetNamespace: cattle-system
+  set:
+    ingress.enabled: "false"
+    ingress.tls.source: "rancher"
+    privateCA: "true"
+    antiAffinity: "required"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rancher-expose
+  namespace: cattle-system
+spec:
+  selector:
+    app: rancher
+  ports:
+    - name: https-internal
+      nodePort: 30444
+      port: 443
+      protocol: TCP
+      targetPort: 444
+  sessionAffinity: ClientIP
+  type: NodePort

--- a/scripts/build
+++ b/scripts/build
@@ -10,6 +10,10 @@ echo "Start building ISO"
 K3S_VERSION=v1.20.4+k3s1
 K3S_IMAGE_URL=https://raw.githubusercontent.com/rancher/k3s/${K3S_VERSION}/scripts/airgap/image-list.txt
 
+RANCHER_VERSION=2.5.7
+RANCHER_IMAGE_URL=https://github.com/rancher/rancher/releases/download/v{$RANCHER_VERSION}/rancher-images.txt
+CERT_MANAGER_VERSION=v1.2.0
+
 # Prepare Harvester chart
 mkdir -p k3os/images/70-iso/charts
 harvester_path=../harvester
@@ -23,6 +27,22 @@ helm package ${harvester_chart_path} -d k3os/images/70-iso/charts
 # Prepare Harvester manifests
 HARVESTER_CHART=$(ls k3os/images/70-iso/charts/harvester* | xargs basename)
 sed -i 's/$HARVESTER_CHART/'$HARVESTER_CHART'/' manifests/harvester.yaml
+
+# Prepare the Rancher chart
+helm pull https://releases.rancher.com/server-charts/latest/rancher-${RANCHER_VERSION}.tgz -d k3os/images/70-iso/charts
+
+# Prepare Rancher manifests
+RANCHER_CHART=$(ls k3os/images/70-iso/charts/rancher* | xargs basename)
+sed -i 's/$RANCHER_CHART/'$RANCHER_CHART'/' manifests/rancher.yaml
+
+# Prepare the cert-manager chart
+helm pull https://charts.jetstack.io/charts/cert-manager-${CERT_MANAGER_VERSION}.tgz -d k3os/images/70-iso/charts
+
+# Prepare cert-manager manifests
+CERT_MANAGER_CHART=$(ls k3os/images/70-iso/charts/cert* | xargs basename)
+sed -i 's/$CERT_MANAGER_CHART/'$CERT_MANAGER_CHART'/' manifests/cert-manager.yaml
+
+# Copy manifests
 cp -r manifests k3os/images/70-iso/
 
 # Offline docker images
@@ -56,6 +76,35 @@ curl ${longhorn_image_url}>>${image_list_file}
 
 # get k3s image list
 curl ${K3S_IMAGE_URL}>>${image_list_file}
+
+# get rancher image list
+RANCHER_REMOTE_IMAGES=rancher-remote-images.txt
+RANCHER_IMAGES=scripts/images/rancher-images.txt
+
+if [ ! -f "$RANCHER_REMOTE_IMAGES" ]; then
+    touch $RANCHER_REMOTE_IMAGES
+fi
+
+curl -fL -o "${RANCHER_REMOTE_IMAGES}" "${RANCHER_IMAGE_URL}"
+
+while IFS= read -r img || [ -n "$img" ]
+do
+  while IFS= read -r img_rq || [ -n "$img_rq" ]
+  do
+    if [[ $img == "$img_rq"* ]]; then
+      echo "$img" >> ${image_list_file}
+    fi
+  done < "$RANCHER_IMAGES"
+done < "$RANCHER_REMOTE_IMAGES"
+echo "Done adding rancher images"
+
+# add cert-manager image list
+CERT_MANAGER_IMAGES=scripts/images/cert-manager-images.txt
+
+while IFS= read -r img || [ -n "$img" ]
+do
+  echo "${img}${CERT_MANAGER_VERSION}">>${image_list_file}
+done < "$CERT_MANAGER_IMAGES"
 
 # format image list
 awk -F ':' '{if($2==""){print $1":latest"}else{print $0}}' "${image_list_file}" | \

--- a/scripts/images/cert-manager-images.txt
+++ b/scripts/images/cert-manager-images.txt
@@ -1,0 +1,3 @@
+quay.io/jetstack/cert-manager-cainjector:
+quay.io/jetstack/cert-manager-controller:
+quay.io/jetstack/cert-manager-webhook:

--- a/scripts/images/rancher-images.txt
+++ b/scripts/images/rancher-images.txt
@@ -1,0 +1,9 @@
+rancher/fleet-agent:
+rancher/fleet:
+rancher/gitjob:
+rancher/library-busybox:
+rancher/pause:
+rancher/rancher-operator:
+rancher/rancher-webhook:
+rancher/rancher:
+rancher/shell:


### PR DESCRIPTION
**Problem:**
Add Rancher deployment manifest to the Harvester and enable by default on HCI mode.

**Solution:**
1. add Rancher & cert-manager manifests
2. expose Rancher by NodePort with the same IP address as the Harvester
3. package offline images

**Related Issue:**
https://github.com/rancher/harvester/issues/513